### PR TITLE
Libreoffice compatibility

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/TextBreak.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBreak.php
@@ -49,7 +49,9 @@ class TextBreak extends Text
 
             $this->endElementP(); // w:p
         } else {
+            $xmlWriter->startElement('w:r');
             $xmlWriter->writeElement('w:br');
+            $xmlWriter->endElement();
         }
     }
 }

--- a/src/PhpWord/Writer/Word2007/Part/Document.php
+++ b/src/PhpWord/Writer/Word2007/Part/Document.php
@@ -65,6 +65,8 @@ class Document extends AbstractPart
                 $containerWriter->write();
 
                 if ($currentSection == $sectionCount) {
+                    $xmlWriter->startElement('w:p');
+                    $xmlWriter->endElement();
                     $this->writeSectionSettings($xmlWriter, $section);
                 } else {
                     $this->writeSection($xmlWriter, $section);


### PR DESCRIPTION
## LibreOffice Compatibility - Section Break:

For all sections except the last section, the sectPr element is stored 
as a child element of the last paragraph in the section. For the last 
section, the sectPr is stored as a child element of the body element.
If there is no p element before the sectPr (e.g. there are only Tables) 
LibreOffice will not make a correct section break.

## LibreOffice Compatibility - Text Break

LibreOffice does not recognize Textbreaks not being wrapped in a r element.

**Incompatibility confirmed for LibreOffice v4 and v5.
Fix tested for LibreOffice v4 and v5, MS Word 2003, 2010 and 2016.**