### PR TITLE
Fix PreserveText preg_split with $limit null

### DIFF
--- a/src/PhpWord/Element/PreserveText.php
+++ b/src/PhpWord/Element/PreserveText.php
@@ -60,7 +60,7 @@ class PreserveText extends AbstractElement
         $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
 
         $this->text = SharedText::toUTF8($text);
-        $matches = preg_split('/({.*?})/', $this->text, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $matches = preg_split('/({.*?})/', $this->text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         if (isset($matches[0])) {
             $this->text = $matches;
         }


### PR DESCRIPTION
### Description

Deprecated in PHP 8.1
- `preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated`

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
