### PR TITLE
Added return type will change to XMLWriter.php

### DIFF
--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -171,6 +171,7 @@ class XMLWriter extends \XMLWriter
      * @param mixed $value
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function writeAttribute($name, $value)
     {
         if (is_float($value)) {


### PR DESCRIPTION
### Description

Added return type will change to XMLWriter.php (PHP8.1 deprecation because internal XMLWriter class expects type hint)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
