### PR TITLE
Sync fork with original (until 0.18.3 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.18.3](https://github.com/PHPOffice/PHPWord/tree/0.18.3) (2022-02-17)
+
+[Full Changelog](https://github.com/PHPOffice/PHPWord/compare/0.18.2...0.18.3)
+
+### Bug fixes
+- PHP 8.1 compatibility
+
 ## [0.18.2](https://github.com/PHPOffice/PHPWord/tree/0.18.2) (2021-06-04)
 
 [Full Changelog](https://github.com/PHPOffice/PHPWord/compare/0.18.1...0.18.2)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "docx", "OOXML", "OpenXML", "Office Open XML", "ISO IEC 29500", "WordprocessingML",
         "RTF", "Rich Text Format", "doc", "odt", "ODF", "OpenDocument", "PDF", "HTML"
     ],
-    "homepage": "http://phpoffice.github.io",
+    "homepage": "https://phpword.readthedocs.io/",
     "type": "library",
     "license": "LGPL-3.0",
     "authors": [

--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -133,6 +133,13 @@ class ZipArchive
 
         if (!$this->usePclzip) {
             $zip = new \ZipArchive();
+
+            // PHP 8.1 compat - passing null as second arg to \ZipArchive::open() is deprecated
+            // passing 0 achieves the same behaviour
+            if ($flags === null) {
+                $flags = 0;
+            }
+
             $result = $zip->open($this->filename, $flags);
 
             // Scrutizer will report the property numFiles does not exist

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -446,7 +446,7 @@ class TemplateProcessor
         if (is_null($value) && isset($inlineValue)) {
             $value = $inlineValue;
         }
-        if (!preg_match('/^([0-9]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
+        if (!preg_match('/^([0-9]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', isset($value) ? $value : '')) {
             $value = null;
         }
         if (is_null($value)) {

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -132,6 +132,14 @@ class TemplateProcessor
         $this->tempDocumentContentTypes = $this->zipClass->getFromName($this->getDocumentContentTypesName());
     }
 
+    public function __destruct()
+    {
+        // if the temp file still exists, remove it when running destruct
+        if ($this->tempDocumentFilename && file_exists($this->tempDocumentFilename) && is_writable($this->tempDocumentFilename)) {
+            @unlink($this->tempDocumentFilename);
+        }
+    }
+
     /**
      * Expose zip class
      *


### PR DESCRIPTION
### Description

Cherry picked all commits of release 0.18.3 in order to publish a compatible version on mraspe/PHPWord

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
